### PR TITLE
BF Add ordinal prefix to tmp files and sort appropriately to maintain…

### DIFF
--- a/example.ipynb
+++ b/example.ipynb
@@ -112,11 +112,7 @@
     {
      "data": {
       "text/html": [
-<<<<<<< HEAD
-       "<iframe src=\"http://127.0.0.1:8888/files/papaya_data/tmpq0PbWH.html\"\n",
-=======
        "<iframe src=\"http://localhost:8889/files/papaya_data/tmp2ocJk_.html\"\n",
->>>>>>> py3
        "                   width=\"600\"\n",
        "                   height=\"450\"\n",
        "                   scrolling=\"no\"\n",
@@ -124,71 +120,20 @@
        "                   </iframe>"
       ],
       "text/plain": [
-<<<<<<< HEAD
-       "<nbpapaya.base.Overlay at 0x103871a10>"
-      ]
-     },
-     "execution_count": 3,
-=======
        "<nbpapaya.base.Surface at 0x104926e90>"
       ]
      },
      "execution_count": 4,
->>>>>>> py3
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-<<<<<<< HEAD
-    "Overlay(MeshOpts, \n",
-    "        port=8888, host=\"127.0.0.1\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "for debugging:"
-=======
     "Surface(\"/Users/keshavan/Dropbox/brainthing/freesurfer_cortex_labels.vtk\", port=8889)"
->>>>>>> py3
    ]
   },
   {
    "cell_type": "code",
-<<<<<<< HEAD
-   "execution_count": 4,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'<iframe src=\"http://127.0.0.1:8888/files/papaya_data/tmpA9ioNT.html\"\\n                   width=\"600\"\\n                   height=\"450\"\\n                   scrolling=\"no\"\\n                   frameBorder=\"0\">\\n                   </iframe>'"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "_3._repr_html_()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Plot just the surface"
-   ]
-  },
-  {
-   "cell_type": "code",
-=======
->>>>>>> py3
    "execution_count": 6,
    "metadata": {
     "collapsed": false
@@ -198,67 +143,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-<<<<<<< HEAD
-      "doing checks /Users/keshavan/.jupyter/custom/\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<iframe src=\"http://127.0.0.1:8888/files/papaya_data/tmpT0XZPO.html\"\n",
-       "                   width=\"600\"\n",
-       "                   height=\"450\"\n",
-       "                   scrolling=\"no\"\n",
-       "                   frameBorder=\"0\">\n",
-       "                   </iframe>"
-      ],
-      "text/plain": [
-       "<nbpapaya.base.Surface at 0x104b96a50>"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "Surface(os.path.abspath(\"nbpapaya_example_data/freesurfer_curvature.vtk\"), \n",
-    "        port=8888, host=\"127.0.0.1\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### plot the volume"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "collapsed": false,
-    "scrolled": false
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "doing checks /Users/keshavan/.jupyter/custom/\n"
-=======
       "doing checks /Users/keshavan/.ipython/profile_default/static/custom/\n"
->>>>>>> py3
      ]
     },
     {
      "data": {
       "text/html": [
-<<<<<<< HEAD
-       "<iframe src=\"http://127.0.0.1:8888/files/papaya_data/tmpNpx5qc.html\"\n",
-=======
        "<iframe src=\"http://localhost:8889/files/papaya_data/tmpDIkXyx.html\"\n",
->>>>>>> py3
        "                   width=\"600\"\n",
        "                   height=\"450\"\n",
        "                   scrolling=\"no\"\n",
@@ -266,27 +157,16 @@
        "                   </iframe>"
       ],
       "text/plain": [
-<<<<<<< HEAD
-       "<nbpapaya.base.Brain at 0x104b96550>"
-      ]
-     },
-     "execution_count": 5,
-=======
        "<nbpapaya.base.Brain at 0x104926d10>"
       ]
      },
      "execution_count": 6,
->>>>>>> py3
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-<<<<<<< HEAD
-    "Brain(os.path.abspath(\"data/001.mgz.nii.gz\"),port=8888, host=\"127.0.0.1\", width=1000, height=1000)"
-=======
     "Brain(\"/Users/keshavan/Dropbox/brainthing/ds008/sub001/anatomy/highres001.nii.gz\",port=8889)"
->>>>>>> py3
    ]
   },
   {
@@ -315,11 +195,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-<<<<<<< HEAD
-   "version": "2.7.10"
-=======
    "version": "2.7.11"
->>>>>>> py3
   }
  },
  "nbformat": 4,

--- a/nbpapaya/base.py
+++ b/nbpapaya/base.py
@@ -10,18 +10,18 @@ class ViewerBase(object):
 
     def _repr_html_(self):
         return """
-            <script type="text/javascript">
-                var nb_port = window.location.port;
-                var iframe = document.querySelector('iframe#{objid}');
-                iframe.src="http://"+window.location.hostname+":" + nb_port + "/files/papaya_data/{objid}.html";
-            </script>
             <iframe
             id="{objid}"
             width="{width}"
             height="{height}"
             scrolling="no"
             frameBorder="0">
-            </iframe>""".format(objid = self.objid, width = self.width, height = self.height)
+            </iframe>
+            <script type="text/javascript">
+                var nb_port = window.location.port;
+                var iframe = document.querySelector('iframe#{objid}');
+                iframe.src="http://"+window.location.hostname+":" + nb_port + "/files/papaya_data/{objid}.html";
+            </script>""".format(objid=self.objid, width=self.width, height=self.height)
 
     def _do_checks(self):
         print("doing checks", self.home_dir)
@@ -54,9 +54,9 @@ class ViewerBase(object):
     def _symlink_files(self, fnames):
         tmp_files = {}
         mapper = {}
-        for i,f in enumerate(fnames):
+        for i, f in enumerate(fnames):
             path, name, ext = split_filename(f)
-            link = mktemp(suffix=ext, dir="papaya_data")
+            link = mktemp(prefix='tmp%02d' % i, suffix=ext, dir="papaya_data")
             os.symlink(f, link)
             _, name, _ = split_filename(link)
             #self.file_names[name + ext] = link
@@ -157,7 +157,7 @@ class Brain(ViewerBase):
         </body>
     </html>
             """
-            html = html.format(images=json(list(self.file_names.keys())),
+            html = html.format(images=json(sorted(list(self.file_names.keys()))),
                                options=opt_json,
                                image_options=imgopt_json)
 

--- a/nbpapaya/brain_view.py
+++ b/nbpapaya/brain_view.py
@@ -71,7 +71,7 @@ def _parse_options(file_names, options, image_options):
         image_options_json = ""
     else:
         opt = []
-        for file, image_options in zip(file_names, image_options):
+        for file, image_options in zip(sorted(file_names), image_options):
             line = "params['{}'] = {};".format(file, json(image_options))
             opt.append(line)
         image_options_json = "\n".join(opt)
@@ -89,12 +89,9 @@ def get_example_data():
     nifti = ""
     from subprocess import check_call
     import os
-    
+
     folder = os.path.abspath("nppapaya_example_data")
     if not os.path.exists(folder):
         os.makedirs(folder)
     cmd = ["wget", vtk]
     check_call(cmd, cwd=folder)
-    
-    
-


### PR DESCRIPTION
Hi Anisha,

Two small fixes here - the first is just removing some diffs that were somehow committed, causing the example.ipynb to break and be invalid json.

The second is a trick to force tmp files to always be sorted consistently. This allows you to use lists of both images and options that will match in the same order. What was happening before was the the images were being copied into a local dir with a unique, autogenerated names. But this actually changed the order of the images stochastically, so that the keys were mapping back haphazardly, causing each LUT option to map to each image randomly. To fix this I appended a prefix to each one and sort them, so that the first image in the list always has the first tmp image, etc., and the key mapping works correctly. This allows you to match options and images, e.g. for positive and negative maps:

    image_options_hot_cold = [
        {'lut': 'Greyscale'}, 
        {'lut':'Red Overlay'}, 
        {'lut': 'Blue Overlay'}]
    Brain([atlas, 'zstat1_pos.nii.gz', 'zstat1_neg.nii.gz'], 
          image_options=image_options_hot_cold)

Otherwise, the tmp filenames map all weird, and re-running will shuffle the three option lists so that they map randomly at each call to the notebook cell.